### PR TITLE
Split files by pressure changes in L2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ L2 processing contains:
 * Flagging data in bins where calculated pressure is negative
 * Flagging data by backscatter increases in upward-facing ADCPs
 * Flagging data below the depth of the sea floor in downward-facing ADCPs
-* Calculation of pressure data from CTD pressure data from the same deployment (if the ADCP was missing a pressure sensor)
+* Optional: Calculation of pressure data from CTD pressure data from the same deployment (if the ADCP was missing a pressure sensor)
+* Optional: Splitting the dataset into segments if there are pressure changes due to mooring strikes. The user must provide the date-times or ensembles at which to split the dataset
 
 *add_var2nc.py* adds a geographic_area variable to a netCDF file from either the L0 or L1 process and exports a new netCDF file containing this addition.
 

--- a/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
+++ b/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
@@ -691,7 +691,8 @@ def write_history(nc, f_name, ds_is_segment=False, ctd_pressure_file=None):
     # Add note about L2 processing steps if applicable
     if ds_is_segment:
         nc.history += ' The dataset was split into segments where water depth changed from mooring strike(s).'
-    elif ctd_pressure_file is not None:
+
+    if ctd_pressure_file is not None:
         nc.history += f' The ADCP dataset was missing (good quality) pressure sensor data,' \
                       f' so pressure sensor data from {ctd_pressure_file} was merged with the ADCP dataset.'
 

--- a/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
+++ b/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
@@ -726,7 +726,7 @@ def write_history(nc, f_name, ds_is_segment=False, ctd_pressure_file=None):
     return
 
 
-def main_header(f, dest_dir, ds_is_segment=False):
+def main_header(f, dest_dir, ds_is_segment=False, ctd_pressure_file=None):
     #Start
     in_f_name = f.split("/")[-1]
     # Create subdir for new netCDF file if one doesn't exist yet
@@ -756,7 +756,8 @@ def main_header(f, dest_dir, ds_is_segment=False):
         write_deployment_recovery(nc=nc_file)
         write_instrument(nc=nc_file)
         write_raw(nc=nc_file)
-        write_history(nc=nc_file, f_name=in_f_name)
+        write_history(nc=nc_file, f_name=in_f_name, ds_is_segment=ds_is_segment,
+                      ctd_pressure_file=ctd_pressure_file)
         sys.stdout.flush() #Recommended by Tom
     finally:
         sys.stdout = orig_stdout

--- a/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
+++ b/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
@@ -690,11 +690,11 @@ def write_history(nc, f_name, ds_is_segment=False, ctd_pressure_file=None):
 
     # Add note about L2 processing steps if applicable
     if ds_is_segment:
-        nc.history += ' The dataset was split into segments where water depth changed from mooring strike(s).'
+        nc.attrs['history'] += ' The dataset was split into segments where water depth changed from mooring strike(s).'
 
     if ctd_pressure_file is not None:
-        nc.history += f' The ADCP dataset was missing (good quality) pressure sensor data,' \
-                      f' so pressure sensor data from {ctd_pressure_file} was merged with the ADCP dataset.'
+        nc.attrs['history'] += f' The ADCP dataset was missing (good quality) pressure sensor data,' \
+                               f' so pressure sensor data from {ctd_pressure_file} was merged with the ADCP dataset.'
 
     n = len(nc.history.split(". "))  # n = len(nc.processing_history.split(". "))
 

--- a/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
+++ b/pycurrents_ADCP_processing/ADCP_IOS_Header_file.py
@@ -671,12 +671,14 @@ def write_raw(nc):
     print()
 
 
-def write_history(nc, f_name):
+def write_history(nc, f_name, ds_is_segment=False, ctd_pressure_file=None):
     # define function to write raw info
     process_1 = "ADCP2NC "
-    process_1_ver = '1' # str(nc.attrs["pred_accuracy"])
+    process_1_ver = '1'  # str(nc.attrs["pred_accuracy"])
     date_time_1 = nc.attrs["date_modified"]
-    digits_in_process_hist = [int(s) for s in nc.attrs['processing_history'].split() if s.isdigit()] #H.Hourston May 27, 2020
+    digits_in_process_hist = [
+        int(s) for s in nc.attrs['processing_history'].split() if s.isdigit()
+    ] #H.Hourston May 27, 2020
     Recs_in_1 = str(digits_in_process_hist[-2] + digits_in_process_hist[-1] + nc.coords["time"].size)
     Recs_out_1 = str(nc.coords["time"].size)
     process_2 = "NC2IOS "
@@ -685,6 +687,14 @@ def write_history(nc, f_name):
     date_time_2 = now.strftime("%Y/%m/%d %H:%M:%S.%f")[0:-7]
     Recs_in_2 = Recs_out_1
     Recs_out_2 = Recs_out_1
+
+    # Add note about L2 processing steps if applicable
+    if ds_is_segment:
+        nc.history += ' The dataset was split into segments where water depth changed from mooring strike(s).'
+    elif ctd_pressure_file is not None:
+        nc.history += f' The ADCP dataset was missing (good quality) pressure sensor data,' \
+                      f' so pressure sensor data from {ctd_pressure_file} was merged with the ADCP dataset.'
+
     n = len(nc.history.split(". "))  # n = len(nc.processing_history.split(". "))
 
     print("*HISTORY")
@@ -715,7 +725,7 @@ def write_history(nc, f_name):
     return
 
 
-def main_header(f, dest_dir):
+def main_header(f, dest_dir, ds_is_segment=False):
     #Start
     in_f_name = f.split("/")[-1]
     # Create subdir for new netCDF file if one doesn't exist yet

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -805,35 +805,25 @@ def make_subset_from_dataset(ds: xr.Dataset, start_idx: int,
 
     # Add attributes and encoding back to the variables
     for var in dsout.keys():
+        try:
+            dsout[var].encoding['_FillValue'] = ds[var].encoding['_FillValue']
+        except KeyError:
+            pass
         for attr, attr_val in ds[var].attrs.items():
             # Recalculate data min and max
             if attr == 'data_min':
-                if 'time' in ds[var].coords:
-                    if 'distance' in ds[var].coords:
-                        ds[var].attrs[attr] = np.nanmin(
-                            ds[var].data[:, start_idx:end_idx])
-                    else:
-                        ds[var].attrs[attr] = np.nanmin(
-                            ds[var].data[start_idx:end_idx])
-                elif 'distance' in ds[var].coords:
-                    ds[var].attrs[attr] = np.nanmin(
-                        ds[var].data)
+                dsout[var].attrs[attr] = np.nanmin(
+                    dsout[var].data)
             elif attr == 'data_max':
-                if 'time' in ds[var].coords:
-                    if 'distance' in ds[var].coords:
-                        ds[var].attrs[attr] = np.nanmax(
-                            ds[var].data[:, start_idx:end_idx])
-                    else:
-                        ds[var].attrs[attr] = np.nanmax(
-                            ds[var].data[start_idx:end_idx])
-                elif 'distance' in ds[var].coords:
-                    ds[var].attrs[attr] = np.nanmax(
-                        ds[var].data)
+                dsout[var].attrs[attr] = np.nanmax(
+                    dsout[var].data)
             # Update sensor depth for each segment
             elif attr == 'sensor_depth':
-                ds[var].attrs[attr] = instrument_depth
+                dsout[var].attrs[attr] = instrument_depth
             else:
-                ds[var].attrs[attr] = attr_val
+                dsout[var].attrs[attr] = attr_val
+
+        # todo add _FillValue variable encoding
 
     # Add global attributes
     for key, value in ds.attrs.items():
@@ -951,7 +941,7 @@ def create_nc_L2(f_adcp: str, dest_dir: str, f_ctd=None, segment_starts_ends=Non
         segment_starts_ends, nc_adcp.PRESPR01.data, nc_adcp.latitude,
         nc_adcp.time.data, nc_adcp.instrument_depth
     )
-
+    print(segment_instr_depths)
     # Initialize list to hold the file names of all netcdf files to be output
     segment_filenames = []
 

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -8,6 +8,7 @@ import xarray as xr
 import matplotlib.pyplot as plt
 import warnings
 import pandas as pd
+import gsw
 from pycurrents_ADCP_processing import plot_westcoast_nc_LX as pwl
 
 
@@ -704,7 +705,126 @@ def reset_vel_minmaxes(d):
     return
 
 
-def create_nc_L2(f_adcp, dest_dir, f_ctd=None):
+def get_user_segment_start_end_idx_depth(
+        segment_starts_ends, pressure, latitude, datetime_pd: np.ndarray):
+    # Convert the user-input segment starts and ends into usable format
+    if type(segment_starts_ends) == dict:
+        # Determine the type of the objects in the list
+        if all([type(k) == str for k in segment_starts_ends.keys()]):
+            # object is a datetime in string format 'YYYYMMDD HH:MM:SS'
+            segment_starts_ends = {
+                pd.to_datetime(k): pd.to_datetime(v)
+                for k, v in segment_starts_ends.items()
+            }
+            # Convert it to an index (integer type)
+            idx = {}
+            for k, v in segment_starts_ends.items():
+                idx_k = np.where(
+                    abs(datetime_pd - pd.to_datetime(k)
+                        ) == min(abs(datetime_pd - pd.to_datetime(k)))
+                )[0]
+                print(idx_k)
+                idx_v = np.where(
+                    abs(datetime_pd - pd.to_datetime(v)
+                        ) == min(abs(datetime_pd - pd.to_datetime(v)))
+                )[0]
+                idx[idx_k[0]] = idx_v[0]
+            segment_start_end_idx = idx
+        elif all([type(k) == int for k in segment_starts_ends.keys()]):
+            segment_start_end_idx = segment_starts_ends
+    elif segment_starts_ends is None:
+        segment_start_end_idx = {0: len(datetime_pd)}  # {0: -1}??
+    else:
+        print(
+            f'Error: segment start and end items are type {type(segment_starts_ends)} and must be dict or None'
+        )
+
+    # Add 1 to the end index because python indexing is not inclusive
+    for k, v in segment_start_end_idx.items():
+        segment_start_end_idx[k] = v + 1
+
+    # Get the mean instrument depth for each segment
+    segment_instrument_depths = np.zeros(
+        len(segment_start_end_idx), dtype='float32')
+
+    for i, k, v in zip(range(len(segment_start_end_idx)),
+                       segment_start_end_idx.keys(),
+                       segment_start_end_idx.values()):
+        # Height (positive up) must be converted to depth (positive down)
+        # Round to 1 decimal place
+        segment_instrument_depths[i] = np.round(np.nanmean(
+                -gsw.z_from_p(pressure[k: v], latitude)), 1)
+
+    return segment_start_end_idx, segment_instrument_depths
+
+
+def make_subset_from_dataset(ds: xr.Dataset, start_idx: int,
+                             end_idx: int, instrument_depth: float):
+    # Have to do all subsetting manually?
+
+    # Add variables
+    # dsout = dsout.assign(LCEWAP01=ds['LCEWAP01'])
+    var_dict = {}
+    for key in ds.data_vars.keys():
+        if key == 'filename':
+            var_dict[key] = ([], ds[key].data)
+        elif 'time' in ds[key].coords:
+            if 'distance' in ds[key].coords:
+                var_dict[key] = (['distance', 'time'],
+                                 ds[key].data[:, start_idx:end_idx])
+            else:
+                var_dict[key] = (['time'],
+                                 ds[key].data[start_idx:end_idx])
+        elif 'distance' in ds[key].coords:
+            var_dict[key] = (['distance'], ds[key].data)
+        else:
+            var_dict[key] = ([], ds[key].data)
+
+    # for key in ds.data_vars.keys():
+    #     dsout = dsout.assign(key=ds[key])
+    #     if 'time' in ds[key].coords:
+    #         if 'distance' in ds[key].coords:
+    #             dsout = dsout.assign(
+    #                 key=(('distance', 'time'),
+    #                      ds[key].data[start_idx:end_idx, :]))
+    #         else:
+    #             dsout = dsout.assign(
+    #                 key=(('time'), ds[key].data[start_idx:end_idx]))
+    #     else:
+    #         dsout = dsout.assign(key=ds[key])
+
+    dsout = xr.Dataset(
+        coords={'time': ds.time.data[start_idx:end_idx],
+                'distance': ds.distance.data}, data_vars=var_dict)
+
+    # Add attributes and encoding back to the variables
+    for var in dsout.keys():
+        for attr, attr_val in ds[var].items():
+            var.attrs[attr] = attr_val
+
+    # Add global attributes
+    for key, value in ds.attrs.items():
+        dsout.attrs[key] = value
+
+    # Update any attributes that are depth- and/or time-dependent
+    GLOBAL_ATTRS_TO_UPDATE = [
+        'instrument_depth', 'processing_history',
+        'time_coverage_duration', 'source', 'time_coverage_start',
+        'time_coverage_end']
+
+    dsout.attrs['instrument_depth'] = instrument_depth
+    dsout.attrs['processing_history'] += ' The data were segmented by pressure changes likely due to a mooring strike.'
+    # duration must be in decimal days format
+    dsout.attrs['time_coverage_duration'] = dsout.time.data[-1] - dsout.time.data[0]
+    dsout.attrs['source'] = 'https://github.com/IOS-OSD-DPG/pycurrents_ADCP_processing'
+    # string format
+    dsout.attrs['time_coverage_start'] = dsout.DTUT8601.data[start_idx] + ' UTC'
+    dsout.attrs['time_coverage_end'] = dsout.DTUT8601.data[end_idx] + ' UTC'
+
+    return dsout
+
+
+def create_nc_L2(f_adcp: str, dest_dir: str, f_ctd=None, segment_starts_ends=None):
     """
     Function for performing the suite of L2 processing methods on netCDF ADCP
     data.
@@ -718,19 +838,19 @@ def create_nc_L2(f_adcp, dest_dir, f_ctd=None):
     if not os.path.exists(dest_dir):
         os.makedirs(dest_dir)
 
-    # Set name for new output netCDF
-    nc_out_name = os.path.basename(f_adcp).replace('L1', 'L2')
-    print(nc_out_name)
-    if not dest_dir.endswith('/') or not dest_dir.endswith('\\'):
-        out_absolute_name = os.path.abspath(dest_dir + '/' + nc_out_name)
-    else:
-        out_absolute_name = os.path.abspath(dest_dir + nc_out_name)
+    # # Set name for new output netCDF
+    # nc_out_name = os.path.basename(f_adcp).replace('L1', 'L2')
+    # print(nc_out_name)
+    # if not dest_dir.endswith('/') or not dest_dir.endswith('\\'):
+    #     out_absolute_name = os.path.abspath(dest_dir + '/' + nc_out_name)
+    # else:
+    #     out_absolute_name = os.path.abspath(dest_dir + nc_out_name)
 
     # Open netCDF ADCP file
     nc_adcp = xr.open_dataset(f_adcp)
 
-    # Change value of filename variable to include "L2" instead of "L1"
-    nc_adcp = nc_adcp.assign(filename=((), nc_out_name[:-3]))
+    # # Change value of filename variable to include "L2" instead of "L1"
+    # nc_adcp = nc_adcp.assign(filename=((), nc_out_name[:-3]))
 
     # Produce pre-processing plots
     plot_diagn = pwl.plots_diagnostic(nc_adcp, dest_dir)
@@ -787,16 +907,57 @@ def create_nc_L2(f_adcp, dest_dir, f_ctd=None):
     # Set bad velocity data to nans
     bad_2_nan(d=nc_adcp)
 
-    # Export the dataset object as a new netCDF file
-    nc_adcp.to_netcdf(out_absolute_name, mode='w', format='NETCDF4')
-    print('Exported L2 netCDF file')
+    # Add segmentation by pressure changes
+    # User inputs indices or datetimes
+    # returns a dictionary of the start and end indices of format {start: end}
+    # and a numpy array of depths with length equal to the dictionary
+    segment_start_end_idx, segment_instr_depths = get_user_segment_start_end_idx_depth(
+        segment_starts_ends, nc_adcp.PRESPR01.data, nc_adcp.latitude,
+        nc_adcp.time.data
+    )
 
-    nc_adcp.close()
+    # Initialize list to hold the file names of all netcdf files to be output
+    segment_filenames = []
 
+    for st_idx, en_idx, depth in zip(
+            segment_start_end_idx.keys(), segment_start_end_idx.values(),
+            segment_instr_depths
+    ):
+        # Generate as many file names as there are segments of data
+        # where the segments were determined from pressure changes
+        # based on the start and end times of the segments and their depths
+        # only use the "date" part of the datetime
+        # format the depth to 4 string characters by adding zeros if necessary
+        out_segment_name = '{}_{}_{}_{}m.adcp.L2.nc'.format(
+            nc_adcp.station,
+            nc_adcp.DTUT8601.data[st_idx][:10].replace('-', ''),
+            nc_adcp.DTUT8601.data[en_idx][:10].replace('-', ''),
+            f'000{str(int(np.round(depth, 0)))}'[-4:])
+
+        absolute_segment_name = os.path.join(dest_dir, out_segment_name)
+
+        segment_filenames.append(absolute_segment_name)
+
+        # split the dataset by creating subsets from the original
+        ds_segment = make_subset_from_dataset(nc_adcp, st_idx, en_idx, depth)
+
+        # Make plot of pressure to show change if dataset is split
+        if len(segment_instr_depths) > 1:
+            segment_pres_plot_name = pwl.plot_adcp_pressure(ds_segment, dest_dir)
+
+        # Export the dataset object as a new netCDF file
+        ds_segment.to_netcdf(absolute_segment_name, mode='w', format='NETCDF4')
+        print(f'Exported L2 netCDF file {out_segment_name}')
+
+        ds_segment.close()
+
+    files_to_return = [*segment_filenames, plot_diagn, plot_backsc]
     if flag_static_pres == 1:
-        return [out_absolute_name, plot_diagn, plot_pres_comp, plot_backsc]
-    else:
-        return [out_absolute_name, plot_diagn, plot_backsc]
+        files_to_return.append(plot_pres_comp)
+    elif len(segment_instr_depths) > 1:
+        files_to_return.append(segment_pres_plot_name)
+
+    return files_to_return
 
 
 def example_L2_1():

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -845,10 +845,13 @@ def make_subset_from_dataset(ds: xr.Dataset, start_idx: int,
         'time_coverage_duration', 'source', 'time_coverage_start',
         'time_coverage_end']
 
+    ns_to_days = 1./(60 * 60 * 24 * 1e9)
+
     dsout.attrs['instrument_depth'] = instrument_depth
     dsout.attrs['processing_history'] += ' The data were segmented by pressure changes likely due to a mooring strike.'
     # duration must be in decimal days format
-    dsout.attrs['time_coverage_duration'] = dsout.time.data[-1] - dsout.time.data[0]
+    dsout.attrs['time_coverage_duration'] = float(
+        dsout.time.data[-1] - dsout.time.data[0]) * ns_to_days
     dsout.attrs['source'] = 'https://github.com/IOS-OSD-DPG/pycurrents_ADCP_processing'
     # string format
     dsout.attrs['time_coverage_start'] = dsout.DTUT8601.data[0] + ' UTC'

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -805,7 +805,7 @@ def make_subset_from_dataset(ds: xr.Dataset, start_idx: int,
 
     # Add attributes and encoding back to the variables
     for var in dsout.keys():
-        for attr, attr_val in ds[var].items():
+        for attr, attr_val in ds[var].attrs.items():
             var.attrs[attr] = attr_val
 
     # Add global attributes

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -737,7 +737,7 @@ def get_user_segment_start_end_idx_depth(
         elif all([type(k) == int for k in segment_starts_ends.keys()]):
             segment_start_end_idx = segment_starts_ends
     elif segment_starts_ends is None:
-        segment_start_end_idx = {0: len(datetime_pd)}  # {0: -1}??
+        segment_start_end_idx = {0: len(datetime_pd) - 1}  # {0: -1}??
     else:
         print(
             f'Error: segment start and end items are type {type(segment_starts_ends)} and must be dict or None'

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -851,8 +851,8 @@ def make_subset_from_dataset(ds: xr.Dataset, start_idx: int,
     dsout.attrs['time_coverage_duration'] = dsout.time.data[-1] - dsout.time.data[0]
     dsout.attrs['source'] = 'https://github.com/IOS-OSD-DPG/pycurrents_ADCP_processing'
     # string format
-    dsout.attrs['time_coverage_start'] = dsout.DTUT8601.data[start_idx] + ' UTC'
-    dsout.attrs['time_coverage_end'] = dsout.DTUT8601.data[end_idx] + ' UTC'
+    dsout.attrs['time_coverage_start'] = dsout.DTUT8601.data[0] + ' UTC'
+    dsout.attrs['time_coverage_end'] = dsout.DTUT8601.data[-1] + ' UTC'
 
     return dsout
 

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -236,10 +236,10 @@ def add_pressure_ctd(nc_adcp: xr.Dataset, nc_ctd: xr.Dataset):
     out_adcp_dataset = nc_adcp.assign(PREXMCAT=(('time'), pres_adcp_from_ctd))
     print('Created new xarray dataset object containing CTD-derived pressure')
 
-    add_attrs_prexmcat(out_adcp_dataset, name_ctd=nc_ctd.filename.data)
+    add_attrs_prexmcat(out_adcp_dataset, name_ctd=str(nc_ctd.filename.data))
     print('Added attributes to PREXMCAT')
 
-    out_adcp_dataset.attrs['processing_history'] += f' CTD pressure data from file {nc_ctd.filename.data} ' \
+    out_adcp_dataset.attrs['processing_history'] += f' CTD pressure data from file {str(nc_ctd.filename.data)} ' \
                                                     f'merged with input ADCP dataset.'
 
     return out_adcp_dataset

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -965,7 +965,7 @@ def create_nc_L2(f_adcp: str, dest_dir: str, f_ctd=None, segment_starts_ends=Non
         # only use the "date" part of the datetime
         # format the depth to 4 string characters by adding zeros if necessary
         out_segment_name = '{}_{}_{}_{}m.adcp.L2.nc'.format(
-            nc_adcp.station,
+            nc_adcp.station.lower(),
             nc_adcp.DTUT8601.data[st_idx][:10].replace('-', ''),
             nc_adcp.DTUT8601.data[en_idx][:10].replace('-', ''),
             f'000{str(int(np.round(depth, 0)))}'[-4:])

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -832,21 +832,30 @@ def make_subset_from_dataset(ds: xr.Dataset, start_idx: int,
     # Update any attributes that are depth- and/or time-dependent
     GLOBAL_ATTRS_TO_UPDATE = [
         'instrument_depth', 'processing_history',
-        'time_coverage_duration', 'source', 'time_coverage_start',
-        'time_coverage_end']
+        'time_coverage_duration', 'time_coverage_start', 'source',
+        'time_coverage_end', 'geospatial_vertical_min',
+        'geospatial_vertical_max']
 
     ns_to_days = 1./(60 * 60 * 24 * 1e9)
+
+    if dsout.orientation == 'up':
+        geospatial_vertical_min = dsout.instrument_depth - np.nanmax(dsout.distance.data)
+        geospatial_vertical_max = dsout.instrument_depth - np.nanmin(dsout.distance.data)
+    elif dsout.orientation == 'down':
+        geospatial_vertical_min = dsout.instrument_depth + np.nanmin(dsout.distance.data)
+        geospatial_vertical_max = dsout.instrument_depth + np.nanmax(dsout.distance.data)
 
     dsout.attrs['instrument_depth'] = instrument_depth
     dsout.attrs['processing_history'] += ' The data were segmented by pressure changes likely due to a mooring strike.'
     # duration must be in decimal days format
     dsout.attrs['time_coverage_duration'] = float(
         dsout.time.data[-1] - dsout.time.data[0]) * ns_to_days
-    dsout.attrs['source'] = 'https://github.com/IOS-OSD-DPG/pycurrents_ADCP_processing'
+    # dsout.attrs['source'] = 'https://github.com/IOS-OSD-DPG/pycurrents_ADCP_processing'
     # string format
     dsout.attrs['time_coverage_start'] = dsout.DTUT8601.data[0] + ' UTC'
     dsout.attrs['time_coverage_end'] = dsout.DTUT8601.data[-1] + ' UTC'
-
+    dsout.attrs['geospatial_vertical_min'] = geospatial_vertical_min
+    dsout.attrs['geospatial_vertical_max'] = geospatial_vertical_max
     return dsout
 
 

--- a/pycurrents_ADCP_processing/ADCP_processing_L2.py
+++ b/pycurrents_ADCP_processing/ADCP_processing_L2.py
@@ -806,7 +806,34 @@ def make_subset_from_dataset(ds: xr.Dataset, start_idx: int,
     # Add attributes and encoding back to the variables
     for var in dsout.keys():
         for attr, attr_val in ds[var].attrs.items():
-            var.attrs[attr] = attr_val
+            # Recalculate data min and max
+            if attr == 'data_min':
+                if 'time' in ds[var].coords:
+                    if 'distance' in ds[var].coords:
+                        ds[var].attrs[attr] = np.nanmin(
+                            ds[var].data[:, start_idx:end_idx])
+                    else:
+                        ds[var].attrs[attr] = np.nanmin(
+                            ds[var].data[start_idx:end_idx])
+                elif 'distance' in ds[var].coords:
+                    ds[var].attrs[attr] = np.nanmin(
+                        ds[var].data)
+            elif attr == 'data_max':
+                if 'time' in ds[var].coords:
+                    if 'distance' in ds[var].coords:
+                        ds[var].attrs[attr] = np.nanmax(
+                            ds[var].data[:, start_idx:end_idx])
+                    else:
+                        ds[var].attrs[attr] = np.nanmax(
+                            ds[var].data[start_idx:end_idx])
+                elif 'distance' in ds[var].coords:
+                    ds[var].attrs[attr] = np.nanmax(
+                        ds[var].data)
+            # Update sensor depth for each segment
+            elif attr == 'sensor_depth':
+                ds[var].attrs[attr] = instrument_depth
+            else:
+                ds[var].attrs[attr] = attr_val
 
     # Add global attributes
     for key, value in ds.attrs.items():

--- a/pycurrents_ADCP_processing/plot_westcoast_nc_LX.py
+++ b/pycurrents_ADCP_processing/plot_westcoast_nc_LX.py
@@ -227,16 +227,17 @@ def plot_adcp_pressure(nc: xr.Dataset, dest_dir: str, resampled=None):
         plt.title("{}-{} {} PRESPR01".format(nc.station, nc.deployment_number,
                                              nc.instrument_serial_number.data))
 
-        png_name = plot_dir + "{}_{}_{}_PRESPR01.png".format(
-            nc.station, nc.deployment_number, nc.instrument_serial_number.data)
+        png_name = plot_dir + "{}-{}_{}_{}m_PRESPR01.png".format(
+            nc.station, nc.deployment_number, nc.instrument_serial_number.data,
+            nc.instrument_depth)
     else:
         plt.title("{}-{} {} PRESPR01 {} subsampled".format(
             nc.station, nc.deployment_number, nc.instrument_serial_number.data,
             resampled))
 
-        png_name = plot_dir + "{}_{}_{}_PRESPR01_{}_subsamp.png".format(
+        png_name = plot_dir + "{}-{}_{}_{}m_PRESPR01_{}_subsamp.png".format(
             nc.station, nc.deployment_number, nc.instrument_serial_number.data,
-            resampled)
+            nc.instrument_depth, resampled)
     
     fig.savefig(png_name)
     plt.close(fig)
@@ -393,8 +394,9 @@ def plots_diagnostic(nc: xr.Dataset, dest_dir, level0=False, time_range=None, bi
     f3 = ax.plot(orientation, depths, linewidth=1, marker='o', markersize=2)
     ax.set_ylim(depths[-1], depths[0])  # set vertical limits
     ax.set_xlabel('Orientation')
-    ax.text(x=middle_orientation, y=mean_depth, s='Mean orientation = {}$^\circ$'.format(
-        str(mean_orientation)), horizontalalignment='center', verticalalignment='center',
+    ax.text(x=middle_orientation, y=mean_depth,
+            s='Mean orientation = {}$^\circ$'.format(str(mean_orientation)),
+            horizontalalignment='center', verticalalignment='center',
             fontsize=10)
     ax.grid()  # set grid
     ax.tick_params(axis='both', direction='in', top=True, right=True)
@@ -412,14 +414,16 @@ def plots_diagnostic(nc: xr.Dataset, dest_dir, level0=False, time_range=None, bi
     if resampled is None:
         fig.suptitle('{}-{} {} at {} m depth'.format(nc.station, nc.deployment_number, nc.serial_number,
                                                      nc.instrument_depth), fontweight='semibold')
-        fig_name = plot_dir + '{}-{}_{}_nc_diagnostic.png'.format(
-            nc.station, str(nc.deployment_number), nc.serial_number)
+        fig_name = plot_dir + '{}-{}_{}_{}m_diagnostic.png'.format(
+            nc.station, str(nc.deployment_number), nc.serial_number,
+            nc.instrument_depth)
     else:
         fig.suptitle('{}-{} {} at {} m depth, {} subsampled'.format(
             nc.station, nc.deployment_number, nc.serial_number, nc.instrument_depth, resampled),
             fontweight='semibold')
-        fig_name = plot_dir + '{}-{}_{}_nc_diagnostic_{}_subsamp.png'.format(
-            nc.station, str(nc.deployment_number), nc.serial_number, resampled)
+        fig_name = plot_dir + '{}-{}_{}_{}m_diagnostic_{}_subsamp.png'.format(
+            nc.station, str(nc.deployment_number), nc.serial_number,
+            nc.instrument_depth, resampled)
 
     fig.savefig(fig_name)
     plt.close()

--- a/pycurrents_ADCP_processing/plot_westcoast_nc_LX.py
+++ b/pycurrents_ADCP_processing/plot_westcoast_nc_LX.py
@@ -60,7 +60,7 @@ def resolve_to_alongcross(u_true, v_true, along_angle):
     return u_along, u_cross
 
 
-def get_L1_start_end(ncdata):
+def get_L1_start_end(ncdata: xr.Dataset):
     """
     Obtain the number of leading and trailing ensembles that were set to nans in L1 processing
     from the processing_history global attribute.
@@ -142,7 +142,7 @@ def fpcdir(x, y):
         return theta
 
 
-def calculate_depths(dataset):
+def calculate_depths(dataset: xr.Dataset):
     """
     Calculate ADCP bin depths in the water column
     Inputs:
@@ -158,7 +158,7 @@ def calculate_depths(dataset):
         return float(dataset.instrument_depth) + dataset.distance.data
 
 
-def vb_flag(dataset):
+def vb_flag(dataset: xr.Dataset):
     """
     Create flag for missing vertical beam data in files from Sentinel V ADCPs
     flag = 0 if Sentinel V file has vertical beam data, or file not from Sentinel V
@@ -201,7 +201,7 @@ def get_plot_dir(filename, dest_dir):
     return plot_dir
 
 
-def plot_adcp_pressure(nc, dest_dir, resampled=None):
+def plot_adcp_pressure(nc: xr.Dataset, dest_dir: str, resampled=None):
     """Plot pressure, PRESPR01, vs time
     :param nc: xarray dataset object from xarray.open_dataset(ncpath)
     :param dest_dir: name of subfolder to which plot will be saved
@@ -244,7 +244,7 @@ def plot_adcp_pressure(nc, dest_dir, resampled=None):
     return png_name
 
 
-def plots_diagnostic(nc, dest_dir, level0=False, time_range=None, bin_range=None, resampled=None):
+def plots_diagnostic(nc: xr.Dataset, dest_dir, level0=False, time_range=None, bin_range=None, resampled=None):
     """
     Preliminary plots:
     (1) Backscatter against depth, (2) mean velocity, and (3) principle component
@@ -427,7 +427,7 @@ def plots_diagnostic(nc, dest_dir, level0=False, time_range=None, bin_range=None
     return os.path.abspath(fig_name)
 
 
-def limit_data(ncdata, ew_data, ns_data, time_range=None, bin_range=None):
+def limit_data(ncdata: xr.Dataset, ew_data, ns_data, time_range=None, bin_range=None):
     """
     Limits data to be plotted to only "good" data, either automatically or with user-input
     time and bin ranges
@@ -497,7 +497,7 @@ def get_vminvmax(v1_data, v2_data):
     return vminvmax
 
 
-def make_pcolor_ne(nc, dest_dir, time_lim, bin_depths_lim, ns_lim, ew_lim, level0=False,
+def make_pcolor_ne(nc: xr.Dataset, dest_dir, time_lim, bin_depths_lim, ns_lim, ew_lim, level0=False,
                    filter_type='raw', colourmap_lim=None, resampled=None):
     """
     Function for plotting north and east velocities from ADCP data.
@@ -634,7 +634,7 @@ def determine_dom_angle(u_true, v_true):
     return along_angle, cross_angle
 
 
-def make_pcolor_ac(data, dest_dir, time_lim, bin_depths_lim, ns_lim, ew_lim, filter_type='raw',
+def make_pcolor_ac(data: xr.Dataset, dest_dir, time_lim, bin_depths_lim, ns_lim, ew_lim, filter_type='raw',
                    along_angle=None, colourmap_lim=None, resampled=None):
     """
     Function for plotting north and east velocities from ADCP data.
@@ -758,7 +758,7 @@ def make_pcolor_ac(data, dest_dir, time_lim, bin_depths_lim, ns_lim, ew_lim, fil
     return os.path.abspath(plot_dir + plot_name)
 
 
-def num_ens_per_hr(nc):
+def num_ens_per_hr(nc: xr.Dataset):
     """
     Calculate the number of ensembles recorded per hour
     :param nc: dataset object obtained from reading in an ADCP netCDF file with the
@@ -772,7 +772,7 @@ def num_ens_per_hr(nc):
     return int(np.round(hr2nsec / time_incr, decimals=0))
 
 
-def filter_godin(nc):
+def filter_godin(nc: xr.Dataset):
     """
     Make North and East lowpassed plots using the simple 3-day Godin filter
     Running average of 24 hours first, then another time with a 24 hour filter,
@@ -820,7 +820,7 @@ def filter_godin(nc):
     return ew_filt_final, ns_filt_final
 
 
-def filter_XXh(nc, num_hrs=30):
+def filter_XXh(nc: xr.Dataset, num_hrs=30):
     """
     Perform XXh averaging on velocity data (30-hour, 35-hour, ...)
     :param nc: xarray Dataset-type object from reading in a netCDF file; contains 1D numpy
@@ -855,7 +855,7 @@ def filter_XXh(nc, num_hrs=30):
     return ew_filt_final, ns_filt_final
 
 
-def binplot_compare_filt(nc, dest_dir, time, dat_raw, dat_filt, filter_type, direction,
+def binplot_compare_filt(nc: xr.Dataset, dest_dir, time, dat_raw, dat_filt, filter_type, direction,
                          resampled=None):
     """
     Function to take one bin from the unfiltered (raw) data and the corresponding bin in
@@ -934,7 +934,7 @@ def binplot_compare_filt(nc, dest_dir, time, dat_raw, dat_filt, filter_type, dir
     return os.path.abspath(plot_dir + plot_name)
 
 
-def resample_adcp_interp(ncname, ncdata):
+def resample_adcp_interp(ncname, ncdata: xr.Dataset):
     # Code from Di Wan
     # Not implemented because this method "creates" data
     u1 = ncdata.resample(time='5min').interpolate("linear")
@@ -962,7 +962,7 @@ def resample_adcp_interp(ncname, ncdata):
     return ncout_name
 
 
-def resample_adcp_manual(ncname, ncdata, dest_dir):
+def resample_adcp_manual(ncname, ncdata: xr.Dataset, dest_dir):
     """Resample netCDF ADCP file for plotting by extracting one ensemble (measurement)
     per 30 min
     :param ncname: Full name including path of the netCDF file

--- a/pycurrents_ADCP_processing/plot_westcoast_nc_LX.py
+++ b/pycurrents_ADCP_processing/plot_westcoast_nc_LX.py
@@ -229,7 +229,7 @@ def plot_adcp_pressure(nc: xr.Dataset, dest_dir: str, resampled=None):
 
         png_name = plot_dir + "{}-{}_{}_{}m_PRESPR01.png".format(
             nc.station, nc.deployment_number, nc.instrument_serial_number.data,
-            nc.instrument_depth)
+            int(np.round(nc.instrument_depth, 0)))
     else:
         plt.title("{}-{} {} PRESPR01 {} subsampled".format(
             nc.station, nc.deployment_number, nc.instrument_serial_number.data,
@@ -237,7 +237,7 @@ def plot_adcp_pressure(nc: xr.Dataset, dest_dir: str, resampled=None):
 
         png_name = plot_dir + "{}-{}_{}_{}m_PRESPR01_{}_subsamp.png".format(
             nc.station, nc.deployment_number, nc.instrument_serial_number.data,
-            nc.instrument_depth, resampled)
+            int(np.round(nc.instrument_depth, 0)), resampled)
     
     fig.savefig(png_name)
     plt.close(fig)
@@ -413,17 +413,18 @@ def plots_diagnostic(nc: xr.Dataset, dest_dir, level0=False, time_range=None, bi
     # Create centred figure title
     if resampled is None:
         fig.suptitle('{}-{} {} at {} m depth'.format(nc.station, nc.deployment_number, nc.serial_number,
-                                                     nc.instrument_depth), fontweight='semibold')
+                                                     np.round(nc.instrument_depth, 1)), fontweight='semibold')
         fig_name = plot_dir + '{}-{}_{}_{}m_diagnostic.png'.format(
             nc.station, str(nc.deployment_number), nc.serial_number,
-            nc.instrument_depth)
+            int(np.round(nc.instrument_depth, 0)))
     else:
         fig.suptitle('{}-{} {} at {} m depth, {} subsampled'.format(
-            nc.station, nc.deployment_number, nc.serial_number, nc.instrument_depth, resampled),
+            nc.station, nc.deployment_number, nc.serial_number,
+            np.round(nc.instrument_depth, 1), resampled),
             fontweight='semibold')
         fig_name = plot_dir + '{}-{}_{}_{}m_diagnostic_{}_subsamp.png'.format(
             nc.station, str(nc.deployment_number), nc.serial_number,
-            nc.instrument_depth, resampled)
+            int(np.round(nc.instrument_depth, 0)), resampled)
 
     fig.savefig(fig_name)
     plt.close()


### PR DESCRIPTION
Update the master branch to allow the user to input start and end date-time strings or indices to split an input L1 ADCP file into segments according to when the mooring was displaced (e.g., by a vessel strike).